### PR TITLE
Fix opened-room event typo

### DIFF
--- a/demo/src/main.vue
+++ b/demo/src/main.vue
@@ -14,7 +14,7 @@
                       :roomId="roomId"
                       v-on:joined-room="logEvent"
                       v-on:left-room="logEvent"
-                      v-on:open-room="logEvent"
+                      v-on:opened-room="logEvent"
                       v-on:share-started="logEvent"
                       v-on:share-stopped="logEvent"
                       @error="onError" />


### PR DESCRIPTION
This will fix a typo in `opened-room ` event.